### PR TITLE
add consolidatedPageCalls logic and tests

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -29,9 +29,10 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
   public static final Factory FACTORY = new Factory() {
     @Override public Integration<?> create(ValueMap settings, Analytics analytics) {
       Logger logger = analytics.logger(MIXPANEL_KEY);
+      boolean consolidatedPageCalls = settings.getBoolean("consolidatedPageCalls", true);
       boolean trackAllPages = settings.getBoolean("trackAllPages", false);
-      boolean trackCategorizedPages = settings.getBoolean("trackCategorizedPages", true);
-      boolean trackNamedPages = settings.getBoolean("trackNamedPages", true);
+      boolean trackCategorizedPages = settings.getBoolean("trackCategorizedPages", false);
+      boolean trackNamedPages = settings.getBoolean("trackNamedPages", false);
       boolean isPeopleEnabled = settings.getBoolean("people", false);
       String token = settings.getString("token");
       Set<String> increments = getStringSet(settings, "increments");
@@ -45,8 +46,18 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
         people = null;
       }
 
-      return new MixpanelIntegration(mixpanel, people, isPeopleEnabled, trackAllPages,
-          trackCategorizedPages, trackNamedPages, token, logger, increments);
+      return new MixpanelIntegration(
+              mixpanel,
+              people,
+              isPeopleEnabled,
+              consolidatedPageCalls,
+              trackAllPages,
+              trackCategorizedPages,
+              trackNamedPages,
+              token,
+              logger,
+              increments
+      );
     }
 
     @Override public String key() {
@@ -72,6 +83,7 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
   final MixpanelAPI mixpanel;
   final MixpanelAPI.People mixpanelPeople;
   final boolean isPeopleEnabled;
+  final boolean consolidatedPageCalls;
   final boolean trackAllPages;
   final boolean trackCategorizedPages;
   final boolean trackNamedPages;
@@ -95,12 +107,22 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
     }
   }
 
-  public MixpanelIntegration(MixpanelAPI mixpanel, MixpanelAPI.People mixpanelPeople,
-      boolean isPeopleEnabled, boolean trackAllPages, boolean trackCategorizedPages,
-      boolean trackNamedPages, String token, Logger logger, Set<String> increments) {
+  public MixpanelIntegration(
+          MixpanelAPI mixpanel,
+          MixpanelAPI.People mixpanelPeople,
+          boolean isPeopleEnabled,
+          boolean consolidatedPageCalls,
+          boolean trackAllPages,
+          boolean trackCategorizedPages,
+          boolean trackNamedPages,
+          String token,
+          Logger logger,
+          Set<String> increments
+  ) {
     this.mixpanel = mixpanel;
     this.mixpanelPeople = mixpanelPeople;
     this.isPeopleEnabled = isPeopleEnabled;
+    this.consolidatedPageCalls = consolidatedPageCalls;
     this.trackAllPages = trackAllPages;
     this.trackCategorizedPages = trackCategorizedPages;
     this.trackNamedPages = trackNamedPages;
@@ -165,6 +187,12 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
   }
 
   @Override public void screen(ScreenPayload screen) {
+    if (consolidatedPageCalls) {
+      Properties properties = screen.properties();
+      properties.put("name", screen.event());
+      event("Loaded a Screen", properties);
+      return;
+    }
     if (trackAllPages) {
       event(String.format(VIEWED_EVENT_FORMAT, screen.event()), screen.properties());
     } else if (trackCategorizedPages && !isNullOrEmpty(screen.category())) {

--- a/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
@@ -68,7 +68,7 @@ public class MixpanelTest {
     when(analytics.logger("Mixpanel")).thenReturn(logger);
     when(analytics.getApplication()).thenReturn(context);
 
-    integration = new MixpanelIntegration(mixpanel, null, false, true, true, true, "foo", logger,
+    integration = new MixpanelIntegration(mixpanel, null, false, true, false, false, false, "foo", logger,
         Collections.<String>emptySet());
   }
 
@@ -163,7 +163,7 @@ public class MixpanelTest {
 
   @Test public void screen() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, false, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, false, false, "foo", logger,
             Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().name("foo").build());
@@ -172,7 +172,7 @@ public class MixpanelTest {
 
   @Test public void screenAllPages() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, false, false, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, false, false, "foo", logger,
             Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().name("foo").build());
@@ -180,9 +180,21 @@ public class MixpanelTest {
     verifyNoMoreMixpanelInteractions();
   }
 
+  @Test public void screenConsolidatedPages() {
+    integration =
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, false, false, true, "foo", logger,
+            Collections.<String>emptySet());
+
+    integration.screen(new ScreenPayloadBuilder().name("foo").build());
+    Properties properties = new Properties();
+    properties.put("name", "foo");
+    verify(mixpanel).track(eq("Loaded a Screen"), jsonEq(properties.toJsonObject()));
+    verifyNoMoreMixpanelInteractions();
+  }
+
   @Test public void screenNamedPages() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, true, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, false, true, "foo", logger,
             Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().name("foo").build());
@@ -195,7 +207,7 @@ public class MixpanelTest {
 
   @Test public void screenCategorizedPages() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, false, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, true, false, "foo", logger,
             Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().category("foo").build());
@@ -214,7 +226,7 @@ public class MixpanelTest {
 
   @Test public void trackIncrement() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, true, true, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
             Collections.singleton("baz"));
 
     integration.track(new TrackPayloadBuilder().event("baz").build());
@@ -256,7 +268,7 @@ public class MixpanelTest {
 
   @Test public void identifyWithPeople() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, true, true, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
             Collections.<String>emptySet());
     Traits traits = createTraits("foo");
     integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
@@ -269,7 +281,7 @@ public class MixpanelTest {
 
   @Test public void identifyWithSuperProperties() throws JSONException {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, true, true, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
             Collections.<String>emptySet());
 
     Traits traits = createTraits("foo")
@@ -305,7 +317,7 @@ public class MixpanelTest {
 
   @Test public void eventWithPeople() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, true, true, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
             Collections.<String>emptySet());
     Properties properties = new Properties();
     integration.event("foo", properties);
@@ -315,7 +327,7 @@ public class MixpanelTest {
 
   @Test public void eventWithPeopleAndRevenue() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, true, true, "foo", logger,
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
             Collections.<String>emptySet());
     Properties properties = new Properties().putRevenue(20);
     integration.event("foo", properties);


### PR DESCRIPTION
This PR adds the `consolidatedPageCalls` setting to this integration that will allow us to migrate our customers to Mixpanel's suggested method of tracking pageviews, with a single event that can differentiated on by the properties attached.
