### PR TITLE
Not call Mixpanel's identify if no userId has been set

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -125,7 +125,7 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
   @Override public void identify(IdentifyPayload identify) {
     super.identify(identify);
     String userId = identify.userId();
-    if (userId != null && userId.length() != 0) {
+    if (userId != null) {
       mixpanel.identify(userId);
       logger.verbose("mixpanel.identify(%s)", userId);
     }

--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -125,8 +125,10 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
   @Override public void identify(IdentifyPayload identify) {
     super.identify(identify);
     String userId = identify.userId();
-    mixpanel.identify(userId);
-    logger.verbose("mixpanel.identify(%s)", userId);
+    if (userId != null && userId.length() != 0) {
+      mixpanel.identify(userId);
+      logger.verbose("mixpanel.identify(%s)", userId);
+    }
     JSONObject traits = new ValueMap(transform(identify.traits(), MAPPER)).toJsonObject();
     mixpanel.registerSuperProperties(traits);
     logger.verbose("mixpanel.registerSuperProperties(%s)", traits);

--- a/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
@@ -33,6 +33,7 @@ import org.robolectric.annotation.Config;
 import static com.segment.analytics.Utils.createTraits;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
@@ -250,6 +251,14 @@ public class MixpanelTest {
     Traits traits = createTraits("foo");
     integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
     verify(mixpanel).identify("foo");
+    verify(mixpanel).registerSuperProperties(jsonEq(traits.toJsonObject()));
+    verifyNoMoreMixpanelInteractions();
+  }
+
+  @Test public void identifyWithoutUserId() {
+    Traits traits = createTraits();
+    integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
+    verify(mixpanel, never()).identify(anyString());
     verify(mixpanel).registerSuperProperties(jsonEq(traits.toJsonObject()));
     verifyNoMoreMixpanelInteractions();
   }


### PR DESCRIPTION
We shouldn't call Mixpanel's identify method if the userId is not set or not valid. We do that check in the iOS platform here: 
https://github.com/segment-integrations/analytics-ios-integration-mixpanel/blob/master/Pod/Classes/SEGMixpanelIntegration.m#L44

This was bringing problems because the anonymous Id for a user changed after calling this identify without any user id. We need to be able to set Traits (or Mixpanel superproperties) before we know a user id (that we get later in the process), and later do an alias call to relate both the anonymous id with our user id. However, calling Mixpanel's identify with a null user id before calling alias was causing issues with the anonymous id changing and being the incorrect id.