### PR TITLE
Update the Mixpanel library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.mixpanel.android:mixpanel-android:4.7.0@aar'
+  compile 'com.mixpanel.android:mixpanel-android:4.8.7@aar'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {


### PR DESCRIPTION
The Mixpanel library is currently at 4.8.7 and this contains some
significant bug fixes, including some issues with assignment of users to
A/B test variants.