### PR TITLE
The Old Me

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -180,9 +180,8 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
     super.alias(alias);
     String previousId = alias.previousId();
     if (previousId.equals(alias.anonymousId())) {
-      // If the previous ID is an anonymous ID, pass null to mixpanel, which has generated it's own
-      // anonymous ID
-      previousId = null;
+      // Instead of using our own anonymousId, we use Mixpanel's own generated Id.
+      previousId = mixpanel.getDistinctId();
     }
     mixpanel.alias(alias.userId(), previousId);
     logger.verbose("mixpanel.alias(%s, %s)", alias.userId(), previousId);

--- a/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
@@ -253,9 +253,12 @@ public class MixpanelTest {
   }
 
   @Test public void aliasWithoutAnonymousId() {
+    String mpDistinctId = "mpDistinctId";
+    when(mixpanel.getDistinctId()).thenReturn(mpDistinctId);
     integration.alias(new AliasPayloadBuilder().traits(new Traits() //
         .putValue("anonymousId", "qaz")).newId("qux").build());
-    verify(mixpanel).alias("qux", null);
+    verify(mixpanel).alias("qux", mpDistinctId);
+    verify(mixpanel).getDistinctId();
     verifyNoMoreMixpanelInteractions();
   }
 


### PR DESCRIPTION
Pass mixpanel's distinctId into alias calls

This matches the iOS integration, and also ensures that if network connectivity delays the `alias` call, the two identities will be properly stitched together.

this fixes #11 