### PR TITLE
Adds peopleProperties and superProperties

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -29,7 +29,6 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
   private static final String VIEWED_EVENT_FORMAT = "Viewed %s Screen";
   public static final Factory FACTORY = new Factory() {
     @Override public Integration<?> create(ValueMap settings, Analytics analytics) {
-      Logger logger = analytics.logger(MIXPANEL_KEY);
       boolean consolidatedPageCalls = settings.getBoolean("consolidatedPageCalls", true);
       boolean trackAllPages = settings.getBoolean("trackAllPages", false);
       boolean trackCategorizedPages = settings.getBoolean("trackCategorizedPages", false);
@@ -37,13 +36,15 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
       boolean isPeopleEnabled = settings.getBoolean("people", false);
       String token = settings.getString("token");
       Set<String> increments = getStringSet(settings, "increments");
-      MixpanelAPI.People people;
       boolean setAllTraitsByDefault = settings.getBoolean("setAllTraitsByDefault", true);
       Set<String> peopleProperties = getStringSet(settings, "peopleProperties");
       Set<String> superProperties = getStringSet(settings, "superProperties");
 
+      Logger logger = analytics.logger(MIXPANEL_KEY);
       MixpanelAPI mixpanel = MixpanelAPI.getInstance(analytics.getApplication(), token);
       logger.verbose("MixpanelAPI.getInstance(context, %s);", token);
+
+      MixpanelAPI.People people;
       if (isPeopleEnabled) {
         people = mixpanel.getPeople();
       } else {

--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -13,7 +13,6 @@ import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
-
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -43,7 +42,6 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
       Set<String> peopleProperties = getStringSet(settings, "peopleProperties");
       Set<String> superProperties = getStringSet(settings, "superProperties");
 
-
       MixpanelAPI mixpanel = MixpanelAPI.getInstance(analytics.getApplication(), token);
       logger.verbose("MixpanelAPI.getInstance(context, %s);", token);
       if (isPeopleEnabled) {
@@ -52,21 +50,9 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
         people = null;
       }
 
-      return new MixpanelIntegration(
-              mixpanel,
-              people,
-              isPeopleEnabled,
-              consolidatedPageCalls,
-              trackAllPages,
-              trackCategorizedPages,
-              trackNamedPages,
-              token,
-              logger,
-              increments,
-              setAllTraitsByDefault,
-              peopleProperties,
-              superProperties
-      );
+      return new MixpanelIntegration(mixpanel, people, isPeopleEnabled, consolidatedPageCalls,
+          trackAllPages, trackCategorizedPages, trackNamedPages, token, logger, increments,
+          setAllTraitsByDefault, peopleProperties, superProperties);
     }
 
     @Override public String key() {
@@ -119,20 +105,11 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
     }
   }
 
-  public MixpanelIntegration(
-          MixpanelAPI mixpanel,
-          MixpanelAPI.People mixpanelPeople,
-          boolean isPeopleEnabled,
-          boolean consolidatedPageCalls,
-          boolean trackAllPages,
-          boolean trackCategorizedPages,
-          boolean trackNamedPages,
-          String token,
-          Logger logger,
-          Set<String> increments,
-          boolean setAllTraitsByDefault,
-          Set<String> peopleProperties,
-          Set<String> superProperties) {
+  public MixpanelIntegration(MixpanelAPI mixpanel, MixpanelAPI.People mixpanelPeople,
+      boolean isPeopleEnabled, boolean consolidatedPageCalls, boolean trackAllPages,
+      boolean trackCategorizedPages, boolean trackNamedPages, String token, Logger logger,
+      Set<String> increments, boolean setAllTraitsByDefault, Set<String> peopleProperties,
+      Set<String> superProperties) {
     this.mixpanel = mixpanel;
     this.mixpanelPeople = mixpanelPeople;
     this.isPeopleEnabled = isPeopleEnabled;
@@ -185,7 +162,6 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
       return;
     }
 
-
     Traits traits = identify.traits();
     Map<String, Object> superPropertyTraits = new LinkedHashMap<>();
     for (String property : superProperties) {
@@ -197,7 +173,7 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
     if (superPropertyTraits.size() != 0) {
       JSONObject superPropertyMappedTraits;
       superPropertyMappedTraits =
-              new ValueMap(transform(superPropertyTraits, MAPPER)).toJsonObject();
+          new ValueMap(transform(superPropertyTraits, MAPPER)).toJsonObject();
       mixpanel.registerSuperProperties(superPropertyMappedTraits);
       logger.verbose("mixpanel.registerSuperProperties(%s)", superPropertyMappedTraits);
 
@@ -210,7 +186,6 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
       return;
     }
 
-
     if (isPeopleEnabled) {
       Map<String, Object> peoplePropertyTraits = new LinkedHashMap<>();
       for (String property : peopleProperties) {
@@ -220,7 +195,7 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
       }
       if (peoplePropertyTraits.size() != 0) {
         JSONObject peoplePropertyMappedTraits =
-                new ValueMap(transform(peoplePropertyTraits, MAPPER)).toJsonObject();
+            new ValueMap(transform(peoplePropertyTraits, MAPPER)).toJsonObject();
         // identify must be called before people properties can be set
         mixpanelPeople.identify(userId);
         logger.verbose("mixpanelPeople.identify(%s)", userId);

--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -196,7 +196,8 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
 
     if (superPropertyTraits.size() != 0) {
       JSONObject superPropertyMappedTraits;
-      superPropertyMappedTraits = new ValueMap(transform(superPropertyTraits, MAPPER)).toJsonObject();
+      superPropertyMappedTraits =
+              new ValueMap(transform(superPropertyTraits, MAPPER)).toJsonObject();
       mixpanel.registerSuperProperties(superPropertyMappedTraits);
       logger.verbose("mixpanel.registerSuperProperties(%s)", superPropertyMappedTraits);
 
@@ -218,7 +219,8 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
         }
       }
       if (peoplePropertyTraits.size() != 0) {
-        JSONObject peoplePropertyMappedTraits = new ValueMap(transform(peoplePropertyTraits, MAPPER)).toJsonObject();
+        JSONObject peoplePropertyMappedTraits =
+                new ValueMap(transform(peoplePropertyTraits, MAPPER)).toJsonObject();
         // identify must be called before people properties can be set
         mixpanelPeople.identify(userId);
         logger.verbose("mixpanelPeople.identify(%s)", userId);

--- a/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegrationBuilder.java
+++ b/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegrationBuilder.java
@@ -1,0 +1,108 @@
+package com.segment.analytics.android.integrations.mixpanel;
+
+import com.mixpanel.android.mpmetrics.MixpanelAPI;
+import com.segment.analytics.Analytics;
+import com.segment.analytics.integrations.Logger;
+import java.util.Collections;
+import java.util.Set;
+
+class MixpanelIntegrationBuilder {
+  private MixpanelAPI mixpanel;
+  private MixpanelAPI.People mixpanelPeople;
+  private boolean isPeopleEnabled;
+  private boolean consolidatedPageCalls;
+  private boolean trackAllPages;
+  private boolean trackCategorizedPages;
+  private boolean trackNamedPages;
+  private String token;
+  private Logger logger;
+  private Set<String> increments;
+  private boolean setAllTraitsByDefault;
+  private Set<String> peopleProperties;
+  private Set<String> superProperties;
+
+  MixpanelIntegrationBuilder() {
+    isPeopleEnabled = false;
+    consolidatedPageCalls = true;
+    trackAllPages = false;
+    trackCategorizedPages = false;
+    trackNamedPages = false;
+    token = "foo";
+    increments = Collections.emptySet();
+    setAllTraitsByDefault = true;
+    peopleProperties = Collections.emptySet();
+    superProperties = Collections.emptySet();
+    logger = Logger.with(Analytics.LogLevel.DEBUG);
+  }
+
+  MixpanelIntegrationBuilder setMixpanel(MixpanelAPI mixpanel) {
+    this.mixpanel = mixpanel;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setMixpanelPeople(MixpanelAPI.People mixpanelPeople) {
+    this.mixpanelPeople = mixpanelPeople;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setIsPeopleEnabled(boolean isPeopleEnabled) {
+    this.isPeopleEnabled = isPeopleEnabled;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setConsolidatedPageCalls(boolean consolidatedPageCalls) {
+    this.consolidatedPageCalls = consolidatedPageCalls;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setTrackAllPages(boolean trackAllPages) {
+    this.trackAllPages = trackAllPages;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setTrackCategorizedPages(boolean trackCategorizedPages) {
+    this.trackCategorizedPages = trackCategorizedPages;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setTrackNamedPages(boolean trackNamedPages) {
+    this.trackNamedPages = trackNamedPages;
+    return this;
+  }
+
+  public MixpanelIntegrationBuilder setToken(String token) {
+    this.token = token;
+    return this;
+  }
+
+  public MixpanelIntegrationBuilder setLogger(Logger logger) {
+    this.logger = logger;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setIncrements(Set<String> increments) {
+    this.increments = increments;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setSetAllTraitsByDefault(boolean setAllTraitsByDefault) {
+    this.setAllTraitsByDefault = setAllTraitsByDefault;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setPeopleProperties(Set<String> peopleProperties) {
+    this.peopleProperties = peopleProperties;
+    return this;
+  }
+
+  MixpanelIntegrationBuilder setSuperProperties(Set<String> superProperties) {
+    this.superProperties = superProperties;
+    return this;
+  }
+
+  MixpanelIntegration createMixpanelIntegration() {
+    return new MixpanelIntegration(mixpanel, mixpanelPeople, isPeopleEnabled, consolidatedPageCalls,
+        trackAllPages, trackCategorizedPages, trackNamedPages, token, logger, increments,
+        setAllTraitsByDefault, peopleProperties, superProperties);
+  }
+}

--- a/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
@@ -48,8 +48,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
 @PowerMockIgnore({ "org.mockito.*", "org.robolectric.*", "android.*", "org.json.*" })
-@PrepareForTest(MixpanelAPI.class)
-public class MixpanelTest {
+@PrepareForTest(MixpanelAPI.class) public class MixpanelTest {
 
   @Rule public PowerMockRule rule = new PowerMockRule();
   @Mock MixpanelAPI mixpanel;
@@ -70,8 +69,8 @@ public class MixpanelTest {
     when(analytics.getApplication()).thenReturn(context);
 
     integration =
-        new MixpanelIntegration(mixpanel, null, false, true, false, false, false, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+        new MixpanelIntegration(mixpanel, null, false, true, false, false, false, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
             Collections.<String>emptySet());
   }
 
@@ -273,6 +272,9 @@ public class MixpanelTest {
   }
 
   @Test public void identify() {
+    assertThat(integration.mixpanelPeople).isNull();
+    assertThat(integration.isPeopleEnabled).isFalse();
+
     Traits traits = createTraits("foo");
     integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
     verify(mixpanel).identify("foo");

--- a/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
@@ -69,8 +69,10 @@ public class MixpanelTest {
     when(analytics.logger("Mixpanel")).thenReturn(logger);
     when(analytics.getApplication()).thenReturn(context);
 
-    integration = new MixpanelIntegration(mixpanel, null, false, true, false, false, false, "foo", logger,
-        Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+    integration =
+        new MixpanelIntegration(mixpanel, null, false, true, false, false, false, "foo", logger,
+            Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
   }
 
   @Test public void factory() {
@@ -166,8 +168,9 @@ public class MixpanelTest {
 
   @Test public void screen() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, false, false, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, false, false, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().name("foo").build());
     verifyNoMoreMixpanelInteractions();
@@ -175,8 +178,9 @@ public class MixpanelTest {
 
   @Test public void screenAllPages() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, false, false, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, false, false, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().name("foo").build());
     verify(mixpanel).track(eq("Viewed foo Screen"), jsonEq(new JSONObject()));
@@ -185,8 +189,9 @@ public class MixpanelTest {
 
   @Test public void screenConsolidatedPages() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, false, false, true, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, true, false, false, true, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().name("foo").build());
     Properties properties = new Properties();
@@ -197,8 +202,9 @@ public class MixpanelTest {
 
   @Test public void screenNamedPages() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, false, true, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, false, true, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().name("foo").build());
     verify(mixpanel).track(eq("Viewed foo Screen"), jsonEq(new JSONObject()));
@@ -210,8 +216,9 @@ public class MixpanelTest {
 
   @Test public void screenCategorizedPages() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, true, false, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, false, true, false, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
 
     integration.screen(new ScreenPayloadBuilder().category("foo").build());
     verify(mixpanel).track(eq("Viewed foo Screen"), jsonEq(new JSONObject()));
@@ -229,8 +236,9 @@ public class MixpanelTest {
 
   @Test public void trackIncrement() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
-            Collections.singleton("baz"), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo",
+            logger, Collections.singleton("baz"), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
 
     integration.track(new TrackPayloadBuilder().event("baz").build());
 
@@ -282,8 +290,9 @@ public class MixpanelTest {
 
   @Test public void identifyWithPeople() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
     Traits traits = createTraits("foo");
     integration.identify(new IdentifyPayloadBuilder().traits(traits).build());
     verify(mixpanel).identify("foo");
@@ -295,11 +304,11 @@ public class MixpanelTest {
 
   @Test public void identifyWithSuperProperties() throws JSONException {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
 
-    Traits traits = createTraits("foo")
-        .putEmail("friends@segment.com")
+    Traits traits = createTraits("foo").putEmail("friends@segment.com")
         .putPhone("1-844-611-0621")
         .putCreatedAt("15th Feb, 2015")
         .putUsername("segmentio");
@@ -323,13 +332,14 @@ public class MixpanelTest {
     verify(mixpanelPeople).set(jsonEq(expected));
     verifyNoMoreMixpanelInteractions();
   }
+
   @Test public void identifyWithSuperPropertiesValues() throws JSONException {
     integration =
-            new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
-                    Collections.<String>emptySet(), false, Collections.<String>emptySet(), Collections.singleton("parasite"));
-    Traits traits = createTraits("foo")
-            .putEmail("Raptor@segment.com")
-            .putValue("parasite", "Photography Raptor");
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo",
+            logger, Collections.<String>emptySet(), false, Collections.<String>emptySet(),
+            Collections.singleton("parasite"));
+    Traits traits = createTraits("foo").putEmail("Raptor@segment.com")
+        .putValue("parasite", "Photography Raptor");
     JSONObject expected = new JSONObject();
     expected.put("parasite", "Photography Raptor");
 
@@ -344,11 +354,11 @@ public class MixpanelTest {
 
   @Test public void identifyWithPeopleProperties() throws JSONException {
     integration =
-            new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
-                    Collections.<String>emptySet(), false, Collections.singleton("parasite"), Collections.<String>emptySet());
-    Traits traits = createTraits("foo")
-            .putEmail("Pencilvester@segment.com")
-            .putValue("parasite", "Pencilvester");
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo",
+            logger, Collections.<String>emptySet(), false, Collections.singleton("parasite"),
+            Collections.<String>emptySet());
+    Traits traits = createTraits("foo").putEmail("Pencilvester@segment.com")
+        .putValue("parasite", "Pencilvester");
     JSONObject expected = new JSONObject();
     expected.put("parasite", "Pencilvester");
 
@@ -370,8 +380,9 @@ public class MixpanelTest {
 
   @Test public void eventWithPeople() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
     Properties properties = new Properties();
     integration.event("foo", properties);
     verify(mixpanel).track(eq("foo"), jsonEq(properties.toJsonObject()));
@@ -380,8 +391,9 @@ public class MixpanelTest {
 
   @Test public void eventWithPeopleAndRevenue() {
     integration =
-        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo", logger,
-            Collections.<String>emptySet(), true, Collections.<String>emptySet(), Collections.<String>emptySet());
+        new MixpanelIntegration(mixpanel, mixpanelPeople, true, false, true, true, true, "foo",
+            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
     Properties properties = new Properties().putRevenue(20);
     integration.event("foo", properties);
     verify(mixpanel).track(eq("foo"), jsonEq(properties.toJsonObject()));

--- a/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/mixpanel/MixpanelTest.java
@@ -15,6 +15,7 @@ import com.segment.analytics.test.ScreenPayloadBuilder;
 import com.segment.analytics.test.TrackPayloadBuilder;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.json.JSONException;
@@ -31,6 +32,7 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.segment.analytics.Utils.createTraits;
+import static com.segment.analytics.android.integrations.mixpanel.MixpanelIntegration.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -69,8 +71,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
     when(analytics.getApplication()).thenReturn(context);
 
     integration =
-        new MixpanelIntegration(mixpanel, null, false, true, false, false, false, "foo",
-            logger, Collections.<String>emptySet(), true, Collections.<String>emptySet(),
+        new MixpanelIntegration(mixpanel, null, false, true, false, false, false, "foo", logger,
+            Collections.<String>emptySet(), true, Collections.<String>emptySet(),
             Collections.<String>emptySet());
   }
 
@@ -371,6 +373,14 @@ import static org.powermock.api.mockito.PowerMockito.when;
     verify(mixpanelPeople).set(jsonEq(expected));
     verify(mixpanelPeople).identify("foo");
     verifyNoMoreMixpanelInteractions();
+  }
+
+  @Test public void testFilter() {
+    Map<String, String> map = Collections.singletonMap("foo", "bar");
+    assertThat(filter(map, Collections.<String>emptySet())).isEqualTo(Collections.emptyMap());
+    assertThat(filter(map, Collections.singletonList("bar"))).isEqualTo(Collections.emptyMap());
+    assertThat(filter(map, Collections.singletonList("foo"))).isEqualTo(
+        Collections.singletonMap("foo", "bar"));
   }
 
   @Test public void event() {


### PR DESCRIPTION
This pulls in `peopleProperties` and `superProperties` when set. The current behavior is to send over all `traits` as `superProperties` and `peopleProperties`, regardless of how a user has configured the traits/properties in the settings panel.

In order for `peopleProperties` to be set in Mixpanel, you must have [Mixpanel People](https://mixpanel.com/help/reference/android#creating_profiles) enabled. In addition, `identify` must be called before people properties can be [set](http://mixpanel.github.io/mixpanel-android/com/mixpanel/android/mpmetrics/MixpanelAPI.People.html#set-java.lang.String-java.lang.Object-).

Super properties doesn't have the same condition, so this checks if they are configured, to call [mixpanel.registerSuperProperties](https://mixpanel.com/help/reference/android#superproperties).

I also added a test to check that the setting `setAllTraitsByDefault` is set to `true` by default. 

[EPD-311](EPD-311)
@hankim813 @anoonan 