### PR TITLE
Bump Mixpanel dep to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
   compile 'com.segment.analytics.android:analytics:4.3.0-RC1'
   testCompile 'com.segment.analytics.android:analytics-tests:4.3.0-RC1'
 
-  compile 'com.mixpanel.android:mixpanel-android:4.9.8@aar'
+  compile 'com.mixpanel.android:mixpanel-android:5.2.1@aar'
 
   testCompile 'junit:junit:4.12'
 


### PR DESCRIPTION
- Bumps Mixpanel dep to 5.2.1
- Doesn't seem to have broken anything (i.e. unit tests still pass and no native methods we use have been deprecated)