### PR TITLE
DAND-11-Update: Bump amplitude dependency from 5.6.3@aar to 5.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 2.2.0 (15th November, 2019)
+==================================
+*(Supports Mixpanel 5.6.5)*
+
+  * Bumps Mixpanel version to 5.6.5
+  * Mixpanel version 5.6.5 fixes and updates [here](https://github.com/mixpanel/mixpanel-android/releases/tag/v5.6.5)
+
 Version 2.1.1 (12th September, 2019)
 ==================================
 *(Supports Mixpanel 5.6.3)*

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'
-  api 'com.mixpanel.android:mixpanel-android:5.6.3@aar'
+  api 'com.mixpanel.android:mixpanel-android:5.6.5'
 
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=2.1.1
+VERSION=2.2.0-SNAPSHOT
 
 POM_ARTIFACT_ID=mixpanel
 POM_PACKAGING=aar


### PR DESCRIPTION
**What does this PR do?**
This PR: Bumps the Mixpanel dependency version from 5.6.3@aar to 5.6.5

**Are there breaking changes in this PR?**
Compiled Successfully and All test passed


**What are the relevant tickets?**
 Jira ticket : [#DEST-1327](https://segmentcontractors.atlassian.net/jira/software/projects/DAND/boards/1?selectedIssue=DAND-11)

**Link to CC ticket**
