### PR TITLE
[DEST-1327] [DAND-11] Bump Mixpanel SDK to 5.6.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 2.2.0 (15th November, 2019)
+==================================
+*(Supports Mixpanel 5.6.5)*
+
+  * Bumps Mixpanel version to 5.6.5
+  * Mixpanel version 5.6.5 fixes and updates [here](https://github.com/mixpanel/mixpanel-android/releases/tag/v5.6.5)
+
 Version 2.1.1 (12th September, 2019)
 ==================================
 *(Supports Mixpanel 5.6.3)*

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'
-  api 'com.mixpanel.android:mixpanel-android:5.6.3@aar'
+  api 'com.mixpanel.android:mixpanel-android:5.6.5'
 
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=2.1.1
+VERSION=2.2.0-SNAPSHOT
 
 POM_ARTIFACT_ID=mixpanel
 POM_PACKAGING=aar


### PR DESCRIPTION
**Related tickets:**
- https://segment.atlassian.net/browse/DEST-1327
- https://segmentcontractors.atlassian.net/browse/DAND-11

We are migrating Mixpanel to the Android monorepo in a separate PR, as I have not yet confirmed that autoreleasing is supported on the monorepo yet. https://github.com/segmentio/analytics-android-integrations/pull/3