### PR TITLE
Kola/dand 60 add support for mixpanel group calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,13 +23,13 @@ android {
   compileSdkVersion 28
 
   defaultConfig {
-    minSdkVersion 14
+    minSdkVersion 16
     targetSdkVersion 28
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
 
   lintOptions {
@@ -37,7 +37,10 @@ android {
   }
 
   testOptions {
-    unitTests.returnDefaultValues = true
+    unitTests{
+      returnDefaultValues = true
+      includeAndroidResources = true
+    }
   }
 }
 
@@ -54,12 +57,13 @@ dependencies {
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.robolectric:robolectric:4.3.1'
+  testImplementation 'org.skyscreamer:jsonassert:1.5.0'
   testImplementation 'org.assertj:assertj-core:1.7.1'
   testImplementation 'org.mockito:mockito-core:3.1.0'
   testImplementation 'org.powermock:powermock:1.6.2'
   testImplementation 'org.powermock:powermock-module-junit4:2.0.4'
   testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.4'
-  testImplementation 'org.powermock:powermock-api-mockito:1.6.2'
+  testImplementation 'org.powermock:powermock-api-mockito2:2.0.4'
   testImplementation 'org.powermock:powermock-classloading-xstream:2.0.4'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,18 +49,18 @@ dependencies {
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'
-  api 'com.mixpanel.android:mixpanel-android:5.6.5'
+  api 'com.mixpanel.android:mixpanel-android:5.6.7'
 
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'
-  testImplementation 'org.robolectric:robolectric:3.3.2'
+  testImplementation 'org.robolectric:robolectric:4.3.1'
   testImplementation 'org.assertj:assertj-core:1.7.1'
-  testImplementation 'org.mockito:mockito-core:1.10.19'
+  testImplementation 'org.mockito:mockito-core:3.1.0'
   testImplementation 'org.powermock:powermock:1.6.2'
-  testImplementation 'org.powermock:powermock-module-junit4:1.6.2'
-  testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.2'
+  testImplementation 'org.powermock:powermock-module-junit4:2.0.4'
+  testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.4'
   testImplementation 'org.powermock:powermock-api-mockito:1.6.2'
-  testImplementation 'org.powermock:powermock-classloading-xstream:1.6.2'
+  testImplementation 'org.powermock:powermock-classloading-xstream:2.0.4'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     jcenter()
     mavenCentral()
     google()
+    maven {
+      url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,6 @@ dependencies {
     jcenter()
     mavenCentral()
     google()
-    maven {
-      url 'https://oss.sonatype.org/content/repositories/snapshots/'
-    }
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'

--- a/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/mixpanel/MixpanelIntegration.java
@@ -8,6 +8,7 @@ import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.AliasPayload;
+import com.segment.analytics.integrations.GroupPayload;
 import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
@@ -285,6 +286,25 @@ public class MixpanelIntegration extends Integration<MixpanelAPI> {
       mixpanelPeople.increment(event, 1);
       mixpanelPeople.set("Last " + event, new Date());
     }
+  }
+
+  @Override
+  public void group(GroupPayload group) {
+    Traits traits = group.traits();
+    String groupId = group.groupId();
+    String groupName = traits.name();
+
+    // set default groupName
+    if (isNullOrEmpty(groupName)) {
+      groupName = "[Segment] Group";
+    }
+    // set group traits
+    if (!isNullOrEmpty(traits)) {
+      mixpanel.getGroup(groupName,groupId).setOnce(traits.toJsonObject());
+    }
+    // set group
+    mixpanel.setGroup(groupName,groupId);
+    logger.verbose("mixpanel.setGroup(%s, %s)", groupName, groupId);
   }
 
   void event(String name, Properties properties) {


### PR DESCRIPTION
**What does this PR do?**
- [x] Add support for Mixpanel Group calls 
- [x] Add test to check `setGroup` and `getGroup` was called 
- [x] Bump mixpanel from 5.6.5 to 5.6.7
- [x] Bump test dependencies 
- [x] Modify test class for the updated dependencies 


- All test passed 

**Are there breaking changes in this PR?**
No breaking changes

**What are the relevant tickets?**
Jira ticket : [#DAND-60](https://segmentcontractors.atlassian.net/jira/software/projects/DAND/boards/1?selectedIssue=DAND-60)

**Helpful Docs**


**Version for this change**
